### PR TITLE
Update Dockerfile

### DIFF
--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -41,7 +41,8 @@ deb-src http://mirrors.aliyun.com/debian/ bookworm-updates main non-free contrib
 COPY requirements.txt .
 
 # 安装 Python 库
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt
 
 # 安装 Playwright 浏览器
 RUN playwright install chromium \


### PR DESCRIPTION
解决可能因为代理或者网络导致的验证失败问题：

```bash
460.7 ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
460.7     unknown package:
460.7         Expected sha256 6a8e34cf4c188b6dd004654f88586d78f95639e48a25dfae9c5e34a6dc34547e
460.7              Got        5350765c4950089d1e46d2e9b3877de439f76e436205c7fa29a1e513f232017c
```